### PR TITLE
feat: implement data pruning for old records

### DIFF
--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -6,6 +6,7 @@ import { PublicKey } from '@solana/web3.js';
 import { db } from './db/client';
 import { fetchMarketData, fetchPoolSnapshot } from './fetchers';
 import { storeMarketData, storePoolSnapshots, storePriceSnapshots } from './services';
+import { pruneOldData } from './services/pruneOldData';
 import { PoolSnapshotRow } from './types';
 import { ADDRESSES_BY_CHAIN, Chain } from './utils/chains';
 import { baseClient, ethereumClient, solanaClient } from './utils/helpers';
@@ -182,6 +183,9 @@ export const runIndexer = async () => {
 
     // Store market data
     await storeMarketData([marketData]);
+
+    // Prune old data
+    await pruneOldData();
   } catch (error) {
     logger.error({ error }, 'Error in runIndexer');
     throw error; // Re-throw to be caught in main

--- a/packages/indexer/src/services/pruneOldData.ts
+++ b/packages/indexer/src/services/pruneOldData.ts
@@ -1,0 +1,41 @@
+import { db } from '../db/client';
+import { logger } from '../utils/logger';
+
+const TABLES_TO_PRUNE = ['market_data', 'pool_snapshots', 'price_snapshots'];
+
+const PRUNE_THRESHOLD_DAYS = 30;
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
+
+let lastPruneTime: number | null = null;
+
+export const pruneOldData = async () => {
+  const now = Date.now();
+
+  if (lastPruneTime && now - lastPruneTime < PRUNE_INTERVAL_MS) {
+    return; // Skip if pruned within last 24h
+  }
+
+  lastPruneTime = now;
+
+  const cutoffDate = new Date(now - PRUNE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000);
+  const cutoffTimestamp = cutoffDate.getTime();
+
+  logger.info({ cutoffDate }, '🧹 Pruning old data');
+
+  for (const table of TABLES_TO_PRUNE) {
+    try {
+      const { rowCount } = await db.query(`DELETE FROM ${table} WHERE timestamp < $1`, [
+        cutoffTimestamp,
+      ]);
+      logger.info({ rowCount, table }, '🗑️ Deleted rows from table');
+
+      const { rows } = await db.query(`SELECT MIN(timestamp) as oldest FROM ${table}`);
+      const oldest = rows[0]?.oldest
+        ? new Date(Number(rows[0].oldest)).toISOString()
+        : 'unknown (table may be empty)';
+      logger.info({ oldest, table }, '📆 Oldest row in table');
+    } catch (err) {
+      logger.error({ error: err, table }, '❌ Failed to prune or fetch oldest row in table');
+    }
+  }
+};


### PR DESCRIPTION
This pull request adds automated pruning of old data from key database tables in the indexer. The main change introduces a new service that periodically deletes records older than 30 days to help manage storage and maintain database performance. The pruning process is triggered during each indexer run but only executes once per day.

**Data retention and maintenance:**

* Added a new service `pruneOldData` in `packages/indexer/src/services/pruneOldData.ts` that deletes records older than 30 days from the `market_data`, `pool_snapshots`, and `price_snapshots` tables, and logs the results.
* Integrated `pruneOldData` into the indexer workflow in `packages/indexer/src/index.ts`, ensuring old data is pruned after market data is stored and only once per day. [[1]](diffhunk://#diff-dda3e96322a3954252553a393e30ab69f00e1529784da8cb9f8c9843da6cf8afR9) [[2]](diffhunk://#diff-dda3e96322a3954252553a393e30ab69f00e1529784da8cb9f8c9843da6cf8afR186-R188)