### PR TITLE
feat: add pool age to pool snapshots

### DIFF
--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -16,6 +16,12 @@ export const POKT_BY_CHAIN: Record<Chain, string> = {
   [Chain.SOLANA]: '6CAsXfiCXZfP8APCG6Vma2DFMindopxiqYQN4LSQfhoC',
 };
 
+const POOL_CREATED_TIMESTAMP: Record<Chain, number> = {
+  [Chain.BASE]: 1724361475,
+  [Chain.ETHEREUM]: 1696841963,
+  [Chain.SOLANA]: 1724398200,
+};
+
 const PRICE_SNAPSHOTS_QUERY = `
   SELECT
     time_bucket($2, to_timestamp(timestamp / 1000.0)) AS bucket,
@@ -112,6 +118,8 @@ export const resolvers = {
       const averageEthereumPrice = averagePriceRows[0]?.average_price ?? 0;
       if (ethereumRows.length > 0) {
         ethereumRows[0].average_price = averageEthereumPrice;
+        ethereumRows[0].pool_age = POOL_CREATED_TIMESTAMP[Chain.ETHEREUM];
+        ethereumRows[0].timestamp = Math.floor(ethereumRows[0].timestamp / 1000);
       }
 
       const { rows: baseRows } = await db.query(POOL_SNAPSHOTS_QUERY, [POKT_BY_CHAIN.base, limit]);
@@ -121,6 +129,8 @@ export const resolvers = {
       const averageBasePrice = averageBasePriceRows[0]?.average_price ?? 0;
       if (baseRows.length > 0) {
         baseRows[0].average_price = averageBasePrice;
+        baseRows[0].pool_age = POOL_CREATED_TIMESTAMP[Chain.BASE];
+        baseRows[0].timestamp = Math.floor(baseRows[0].timestamp / 1000);
       }
 
       const { rows: solanaRows } = await db.query(POOL_SNAPSHOTS_QUERY, [
@@ -133,6 +143,8 @@ export const resolvers = {
       const averageSolanaPrice = averageSolanaPriceRows[0]?.average_price ?? 0;
       if (solanaRows.length > 0) {
         solanaRows[0].average_price = averageSolanaPrice;
+        solanaRows[0].pool_age = POOL_CREATED_TIMESTAMP[Chain.SOLANA];
+        solanaRows[0].timestamp = Math.floor(solanaRows[0].timestamp / 1000);
       }
 
       return {
@@ -157,18 +169,18 @@ export const resolvers = {
       return {
         base: baseRows.map((row) => ({
           ...row,
-          // Floor timestamp to the nearest minute
-          timestamp: new Date(Math.floor(Number(row.timestamp) / 60000) * 60000).toISOString(),
+          // Floor timestamp to the nearest minute in seconds
+          timestamp: Math.floor(Number(row.timestamp) / 60000) * 60,
         })),
         ethereum: ethereumRows.map((row) => ({
           ...row,
-          // Floor timestamp to the nearest minute
-          timestamp: new Date(Math.floor(Number(row.timestamp) / 60000) * 60000).toISOString(),
+          // Floor timestamp to the nearest minute in seconds
+          timestamp: Math.floor(Number(row.timestamp) / 60000) * 60,
         })),
         solana: solanaRows.map((row) => ({
           ...row,
-          // Floor timestamp to the nearest minute
-          timestamp: new Date(Math.floor(Number(row.timestamp) / 60000) * 60000).toISOString(),
+          // Floor timestamp to the nearest minute in seconds
+          timestamp: Math.floor(Number(row.timestamp) / 60000) * 60,
         })),
       };
     },

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -22,7 +22,7 @@ export const typeDefs = gql`
     day_volume: Float!
     market_cap: Float!
     price: Float!
-    timestamp: String!
+    timestamp: Int!
   }
 
   type PoolSnapshotRow {
@@ -34,7 +34,8 @@ export const typeDefs = gql`
     holders: Float!
     market_cap: Float!
     pool_address: String!
-    timestamp: String!
+    pool_age: Int!
+    timestamp: Int!
     token_address: String!
     tvl_usd: Float!
     volatility: Float!
@@ -53,7 +54,7 @@ export const typeDefs = gql`
     exchange: String!
     pool_address: String!
     price: Float!
-    timestamp: String!
+    timestamp: Int!
     token_address: String!
   }
 


### PR DESCRIPTION
This pull request updates the pool snapshot API to improve timestamp handling and add pool age metadata. The main changes include switching timestamp fields from strings to integers (representing seconds), introducing a `pool_age` field, and updating the resolver logic to consistently handle timestamps and pool age for each chain.

**Schema and API Response Updates:**

* Changed all `timestamp` fields in the GraphQL schema from `String!` to `Int!`, ensuring timestamps are returned as integer seconds instead of ISO strings. [[1]](diffhunk://#diff-5d3887fa343151a6c0b551340c7afb5b055005d39ef22bba90f660fabf1afd9dL25-R25) [[2]](diffhunk://#diff-5d3887fa343151a6c0b551340c7afb5b055005d39ef22bba90f660fabf1afd9dL56-R57)
* Added a new `pool_age` field of type `Int!` to the `PoolSnapshotRow` type in the GraphQL schema, providing the pool creation time for each chain.

**Resolver Logic Improvements:**

* Added a `POOL_CREATED_TIMESTAMP` constant mapping each chain to its pool creation timestamp, and included this metadata in resolver responses for each chain.
* Updated resolver logic to floor the timestamp to the nearest minute (in seconds) and return it as an integer, ensuring consistency across chains.
* Modified resolver output to include the `pool_age` and properly convert timestamps to seconds for each chain's data row. [[1]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612R121-R122) [[2]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612R132-R133) [[3]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612R146-R147)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field displaying pool age in pool snapshot data.

* **Improvements**
  * Timestamps in market data, pool snapshots, and price snapshots are now provided as integers (in seconds) instead of strings for improved consistency and ease of use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->