### PR TITLE
feat: bring back improved health endpoint

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -24,7 +24,7 @@ async function startServer() {
   const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
 
   let alreadyAlerted = false;
-  const LAST_RUN_QUERY = 'SELECT timestamp FROM price_snapshots ORDER BY timestamp DESC LIMIT 1';
+  const LAST_RUN_QUERY = 'SELECT MAX(timestamp) as timestamp FROM price_snapshots';
 
   app.get('/healthz', async (_, res) => {
     try {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,9 +3,10 @@ import 'dotenv/config';
 import { ApolloServer } from 'apollo-server-express';
 import express from 'express';
 
+import { db } from './db';
 import { resolvers } from './resolvers';
 import { typeDefs } from './schema';
-// import { sendIndexerAlertEmail } from './utils/mailer';
+import { sendIndexerAlertEmail } from './utils/mailer';
 
 async function startServer() {
   const app = express();
@@ -22,37 +23,33 @@ async function startServer() {
   const host = process.env.HOST || 'localhost';
   const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
 
-  app.get('/health', async (req, res) => {
+  let alreadyAlerted = false;
+  const LAST_RUN_QUERY = 'SELECT timestamp FROM price_snapshots ORDER BY timestamp DESC LIMIT 1';
+
+  app.get('/healthz', async (_, res) => {
     try {
-      // TODO: Add improved health check later
+      const now = Date.now();
+      const { rows } = await db.query(LAST_RUN_QUERY);
+      const lastIndexerRun = rows[0]?.timestamp ? BigInt(rows[0].timestamp) : null;
 
-      // const lastRun = await redis.get('indexer:lastRun');
-      // const alertKey = 'indexer:alertSent';
-      // const now = Date.now();
+      if (!lastIndexerRun) {
+        if (!alreadyAlerted) {
+          await sendIndexerAlertEmail('never');
+          alreadyAlerted = true;
+        }
+        return res.status(200).send('No lastIndexerRun recorded');
+      }
 
-      // if (!lastRun) {
-      //   const alreadyAlerted = await redis.get(alertKey);
-      //   if (!alreadyAlerted) {
-      //     await sendIndexerAlertEmail('never');
-      //     await redis.set(alertKey, '1', 'EX', 3600); // 1-hour cooldown
-      //   }
-      //   return res.status(200).send('No lastRun recorded');
-      // }
+      const diff = now - Number(lastIndexerRun);
+      const threshold = 20 * 60 * 1000; // 20 minutes
 
-      // const diff = now - Number(lastRun);
-      // const threshold = 20 * 60 * 1000; // 20 minutes
-
-      // if (diff > threshold) {
-      //   const alreadyAlerted = await redis.get(alertKey);
-      //   if (!alreadyAlerted) {
-      //     await sendIndexerAlertEmail(new Date(Number(lastRun)).toISOString());
-      //     await redis.set(alertKey, '1', 'EX', 3600); // 1-hour cooldown
-      //   }
-      //   return res.status(200).send(`Stale indexer: last run ${Math.floor(diff / 60000)} min ago`);
-      // }
-
-      // // Reset the alert flag if the indexer is back to normal
-      // await redis.del(alertKey);
+      if (diff > threshold) {
+        if (!alreadyAlerted) {
+          await sendIndexerAlertEmail(new Date(Number(lastIndexerRun)).toISOString());
+          alreadyAlerted = true;
+        }
+        return res.status(200).send(`Stale indexer: last run ${Math.floor(diff / 60000)} min ago`);
+      }
 
       return res.status(200).send('ok');
     } catch (err) {


### PR DESCRIPTION
This pull request updates the health check endpoint in the API server to improve monitoring of the indexer and to send alert emails if the indexer is stale or has never run. The changes include switching to a new `/healthz` endpoint, querying the database for the latest indexer run, and sending alert emails when necessary.

**Health check improvements:**

* Replaces the `/health` endpoint with a new `/healthz` endpoint that checks the most recent indexer run by querying the `price_snapshots` table for the latest timestamp.
* Adds logic to send an alert email using `sendIndexerAlertEmail` if the indexer has never run or if the last run was more than 20 minutes ago. The alert is only sent once per process lifetime to avoid spamming.
* Removes commented-out Redis-based alert logic and replaces it with a simpler in-memory `alreadyAlerted` flag.

**Dependency and import updates:**

* Enables the import of `db` and `sendIndexerAlertEmail` in `index.ts`, which are now used in the health check logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the health check endpoint to provide more accurate status by checking the latest data in the database.
  * Enhanced alert system to notify when the indexer is stale or has never run, with improved cooldown logic to prevent repeated alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->