### PR TITLE
fix: price_snapshots timestamp bucketing

### DIFF
--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -30,11 +30,10 @@ const PRICE_SNAPSHOTS_QUERY = `
     token_address,
     pool_address,
     chain,
-    exchange,
-    block_number
+    exchange
   FROM price_snapshots
   WHERE token_address = $1
-  GROUP BY bucket, token_address, pool_address, chain, exchange, block_number
+  GROUP BY bucket, token_address, pool_address, chain, exchange
   ORDER BY bucket DESC
   LIMIT $3
 `;
@@ -82,6 +81,12 @@ const DAY_LOW_PRICE_QUERY = `
   WHERE token_address = $1
     AND to_timestamp(timestamp / 1000.0) >= NOW() - INTERVAL '24 hours'
 `;
+
+const intervalToMultiplier: Record<'_15m' | '_30m' | '_1h', number> = {
+  _15m: 15,
+  _30m: 30,
+  _1h: 60,
+};
 
 export const resolvers = {
   Query: {
@@ -169,18 +174,24 @@ export const resolvers = {
       return {
         base: baseRows.map((row) => ({
           ...row,
-          // Round timestamp to the nearest 15 minute interval in seconds
-          timestamp: Math.round(Number(row.timestamp) / (15 * 60 * 1000)) * (15 * 60),
+          // Round timestamp to the nearest interval in seconds
+          timestamp:
+            Math.round(Number(row.timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
+            (intervalToMultiplier[interval] * 60),
         })),
         ethereum: ethereumRows.map((row) => ({
           ...row,
-          // Round timestamp to the nearest 15 minute interval in seconds
-          timestamp: Math.round(Number(row.timestamp) / (15 * 60 * 1000)) * (15 * 60),
+          // Round timestamp to the nearest interval in seconds
+          timestamp:
+            Math.round(Number(row.timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
+            (intervalToMultiplier[interval] * 60),
         })),
         solana: solanaRows.map((row) => ({
           ...row,
-          // Round timestamp to the nearest 15 minute interval in seconds
-          timestamp: Math.round(Number(row.timestamp) / (15 * 60 * 1000)) * (15 * 60),
+          // Round timestamp to the nearest interval in seconds
+          timestamp:
+            Math.round(Number(row.timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
+            (intervalToMultiplier[interval] * 60),
         })),
       };
     },

--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -88,6 +88,13 @@ const intervalToMultiplier: Record<'_15m' | '_30m' | '_1h', number> = {
   _1h: 60,
 };
 
+const roundTimestampToInterval = (timestamp: number, interval: '_15m' | '_30m' | '_1h'): number => {
+  return (
+    Math.round(Number(timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
+    (intervalToMultiplier[interval] * 60)
+  );
+};
+
 export const resolvers = {
   Query: {
     marketData: async () => {
@@ -174,24 +181,15 @@ export const resolvers = {
       return {
         base: baseRows.map((row) => ({
           ...row,
-          // Round timestamp to the nearest interval in seconds
-          timestamp:
-            Math.round(Number(row.timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
-            (intervalToMultiplier[interval] * 60),
+          timestamp: roundTimestampToInterval(row.timestamp, interval),
         })),
         ethereum: ethereumRows.map((row) => ({
           ...row,
-          // Round timestamp to the nearest interval in seconds
-          timestamp:
-            Math.round(Number(row.timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
-            (intervalToMultiplier[interval] * 60),
+          timestamp: roundTimestampToInterval(row.timestamp, interval),
         })),
         solana: solanaRows.map((row) => ({
           ...row,
-          // Round timestamp to the nearest interval in seconds
-          timestamp:
-            Math.round(Number(row.timestamp) / (intervalToMultiplier[interval] * 60 * 1000)) *
-            (intervalToMultiplier[interval] * 60),
+          timestamp: roundTimestampToInterval(row.timestamp, interval),
         })),
       };
     },

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -49,7 +49,6 @@ export const typeDefs = gql`
   }
 
   type PriceSnapshot {
-    block_number: String!
     chain: Chain!
     exchange: String!
     pool_address: String!


### PR DESCRIPTION
This pull request updates the logic for price snapshot queries and timestamp rounding in the API, making the system more flexible and accurate in handling different time intervals. The changes also remove the unused `block_number` field from the GraphQL schema.

**API Query and Data Processing Improvements:**

* Updated the `PRICE_SNAPSHOTS_QUERY` SQL to remove `block_number` from the selected fields and the `GROUP BY` clause, reflecting that this field is no longer needed.
* Introduced an `intervalToMultiplier` mapping to support dynamic interval rounding (15m, 30m, 1h), and updated the timestamp rounding logic in the resolver to use this mapping instead of a hardcoded 15-minute interval. This allows for more flexible aggregation of price data. [[1]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612R85-R90) [[2]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612L172-R194)

**Schema Cleanup:**

* Removed the `block_number` field from the `PriceSnapshot` GraphQL type definition, as it is no longer used in the API response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price snapshots now support selectable intervals (15m, 30m, 1h) with dynamic timestamp bucketing applied across Base, Ethereum, and Solana; aggregation occurs per interval bucket (by token/address, chain, and exchange).

* **Refactor**
  * Removed the block_number field from PriceSnapshot in the API, simplifying snapshot outputs — this is a breaking change for API consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->