### PR TITLE
feat: use Moralis for 24 hour volume stat

### DIFF
--- a/packages/indexer/src/fetchers/theGraphClient.ts
+++ b/packages/indexer/src/fetchers/theGraphClient.ts
@@ -54,14 +54,6 @@ class TheGraphEthereumClient extends TheGraphGenericClient {
             reserveUSD
             token1Price
           }
-          pairDayDatas(
-            first: 1
-            orderBy: date
-            orderDirection: desc
-            where: { pairAddress: $poolAddress, date_lt: $ltDate }
-          ) {
-            dailyVolumeToken1
-          }
         }
       `,
       {
@@ -75,12 +67,9 @@ class TheGraphEthereumClient extends TheGraphGenericClient {
         reserveUSD: string;
         token1Price: string;
       };
-      pairDayDatas: Array<{
-        dailyVolumeToken1: string;
-      }>;
     };
 
-    return { ...data.pair, volumeETH: data.pairDayDatas[0]?.dailyVolumeToken1 ?? '0' };
+    return { ...data.pair };
   }
 }
 
@@ -110,14 +99,6 @@ class TheGraphBaseClient extends TheGraphGenericClient {
             totalValueLockedToken0
             volumeUSD
           }
-          poolDayDatas(
-            first: 1
-            orderBy: date
-            orderDirection: desc
-            where: { pool: $poolAddress, date_lt: $ltDate }
-          ) {
-            volumeToken0
-          }
         }
       `,
       {
@@ -131,12 +112,9 @@ class TheGraphBaseClient extends TheGraphGenericClient {
         totalValueLockedToken0: string;
         volumeUSD: string;
       };
-      poolDayDatas: Array<{
-        volumeToken0: string;
-      }>;
     };
 
-    return { ...data.pool, volumeETH: data.poolDayDatas[0]?.volumeToken0 ?? '0' };
+    return { ...data.pool };
   }
 }
 


### PR DESCRIPTION
This pull request updates how pool volume data is fetched and calculated in the indexer. Instead of relying on The Graph for daily volume data, the code now uses the Moralis client’s `getTokenPairStats` to obtain more accurate and direct 24-hour volume statistics. The Graph queries and associated logic for daily volume have been removed accordingly.

**Switch to Moralis for 24h Volume Data:**

* Added calls to `moralisClient.evm.getTokenPairStats` in `fetchPoolSnapshot` to fetch 24-hour volume directly for both Ethereum and Base chains, using retry logic and logging on retry attempts. [[1]](diffhunk://#diff-696d25f1aef402ac08fb9f93d74d4c6d7167579342d9141223531ec6290933d5R48-R62) [[2]](diffhunk://#diff-696d25f1aef402ac08fb9f93d74d4c6d7167579342d9141223531ec6290933d5R118-R132)
* Updated the calculation of `volume_usd` and `volatility` to use the 24-hour volume from Moralis instead of previously calculated values based on The Graph data. [[1]](diffhunk://#diff-696d25f1aef402ac08fb9f93d74d4c6d7167579342d9141223531ec6290933d5L63-R79) [[2]](diffhunk://#diff-696d25f1aef402ac08fb9f93d74d4c6d7167579342d9141223531ec6290933d5L134-R164) [[3]](diffhunk://#diff-696d25f1aef402ac08fb9f93d74d4c6d7167579342d9141223531ec6290933d5L118-L120)

**Removal of The Graph Volume Queries:**

* Removed `pairDayDatas` and `poolDayDatas` GraphQL queries and related code from `TheGraphEthereumClient` and `TheGraphBaseClient`, as well as the logic for extracting daily volume from these queries. [[1]](diffhunk://#diff-cafedb3d21d6a3b306dd1eafdd6188d1970fa8c43981f4de53647a8a61a7f5acL57-L64) [[2]](diffhunk://#diff-cafedb3d21d6a3b306dd1eafdd6188d1970fa8c43981f4de53647a8a61a7f5acL78-R72) [[3]](diffhunk://#diff-cafedb3d21d6a3b306dd1eafdd6188d1970fa8c43981f4de53647a8a61a7f5acL113-L120) [[4]](diffhunk://#diff-cafedb3d21d6a3b306dd1eafdd6188d1970fa8c43981f4de53647a8a61a7f5acL134-R117)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Use an external 24h volume source to improve ETH and Base volume measurements.

- Bug Fixes
  - Corrected 24h volume and volatility calculations for ETH and Base pools; Solana unchanged.

- Refactor
  - Removed redundant daily-volume queries and simplified pool stats retrieval; added retry logging for volume fetches.

- Tests
  - Updated tests to mock and validate the new 24h volume data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->