### PR TITLE
feat: add avg_price_change_perc field to API

### DIFF
--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -156,7 +156,7 @@ export const resolvers = {
       for (const r of poolRows) {
         // rn=1 row will naturally overwrite later ones; we only need the most recent per token
         if (!latestByToken[r.token_address]) {
-          latestByToken[r.token_address] = { ...r };
+          latestByToken[r.token_address] = { ...r, avg_price_change_perc: 0 };
         }
       }
 

--- a/packages/api/src/resolvers.ts
+++ b/packages/api/src/resolvers.ts
@@ -145,7 +145,13 @@ export const resolvers = {
       // Map helpers
       const latestByToken: Record<
         string,
-        { average_price: number; pool_age: number; timestamp: number; token_address: string }
+        {
+          average_price: number;
+          avg_price_change_perc: number;
+          pool_age: number;
+          timestamp: number;
+          token_address: string;
+        }
       > = {};
       for (const r of poolRows) {
         // rn=1 row will naturally overwrite later ones; we only need the most recent per token
@@ -154,14 +160,28 @@ export const resolvers = {
         }
       }
 
-      const statsByToken: Record<string, { avg_24h: number; max_24h: number; min_24h: number }> =
-        {};
+      const { rows: prevStatsRows } = await (async () => {
+        const nowMs = Date.now();
+        const from48hMs = nowMs - 48 * 60 * 60 * 1000;
+        const to24hMs = nowMs - 24 * 60 * 60 * 1000;
+        return db.query(STATS_24H_SQL, [from48hMs, to24hMs]);
+      })();
+
+      const statsByToken: Record<
+        string,
+        { avg_24h: number; max_24h: number; min_24h: number; prev_avg_24h: number }
+      > = {};
       for (const r of statsRows) {
         statsByToken[r.token_address] = {
           avg_24h: Number(r.avg_24h ?? 0),
           max_24h: Number(r.max_24h ?? 0),
           min_24h: Number(r.min_24h ?? 0),
+          prev_avg_24h: 0,
         };
+      }
+
+      for (const r of prevStatsRows) {
+        statsByToken[r.token_address].prev_avg_24h = Number(r.avg_24h ?? 0);
       }
 
       const baseRow = latestByToken[POKT_BY_CHAIN.base];
@@ -172,16 +192,40 @@ export const resolvers = {
         baseRow.average_price = statsByToken[POKT_BY_CHAIN.base]?.avg_24h ?? 0;
         baseRow.pool_age = POOL_CREATED_TIMESTAMP[Chain.BASE];
         baseRow.timestamp = Math.floor(baseRow.timestamp / 1000);
+
+        const prevAverageprice = statsByToken[POKT_BY_CHAIN.base]?.prev_avg_24h ?? 0;
+        if (prevAverageprice) {
+          baseRow.avg_price_change_perc =
+            (baseRow.average_price - prevAverageprice) / prevAverageprice;
+        } else {
+          baseRow.avg_price_change_perc = 0;
+        }
       }
       if (ethRow) {
         ethRow.average_price = statsByToken[POKT_BY_CHAIN.ethereum]?.avg_24h ?? 0;
         ethRow.pool_age = POOL_CREATED_TIMESTAMP[Chain.ETHEREUM];
         ethRow.timestamp = Math.floor(ethRow.timestamp / 1000);
+
+        const prevAverageprice = statsByToken[POKT_BY_CHAIN.ethereum]?.prev_avg_24h ?? 0;
+        if (prevAverageprice) {
+          ethRow.avg_price_change_perc =
+            (ethRow.average_price - prevAverageprice) / prevAverageprice;
+        } else {
+          ethRow.avg_price_change_perc = 0;
+        }
       }
       if (solRow) {
         solRow.average_price = statsByToken[POKT_BY_CHAIN.solana]?.avg_24h ?? 0;
         solRow.pool_age = POOL_CREATED_TIMESTAMP[Chain.SOLANA];
         solRow.timestamp = Math.floor(solRow.timestamp / 1000);
+
+        const prevAverageprice = statsByToken[POKT_BY_CHAIN.solana]?.prev_avg_24h ?? 0;
+        if (prevAverageprice) {
+          solRow.avg_price_change_perc =
+            (solRow.average_price - prevAverageprice) / prevAverageprice;
+        } else {
+          solRow.avg_price_change_perc = 0;
+        }
       }
 
       return {

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -27,6 +27,7 @@ export const typeDefs = gql`
 
   type PoolSnapshotRow {
     average_price: Float!
+    avg_price_change_perc: Float!
     block_number: String!
     chain: Chain!
     circulating_supply: Float!

--- a/packages/api/tests/unit/resolvers/poolSnapshots.test.ts
+++ b/packages/api/tests/unit/resolvers/poolSnapshots.test.ts
@@ -61,6 +61,28 @@ describe('Query.poolSnapshots', () => {
             min_24h: 0,
           },
         ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token_address: '0x764a726d9ced0433a8d7643335919deb03a9a935',
+            avg_24h: 0.35,
+            max_24h: 0,
+            min_24h: 0,
+          },
+          {
+            token_address: '0x67f4c72a50f8df6487720261e188f2abe83f57d7',
+            avg_24h: 0.38,
+            max_24h: 0,
+            min_24h: 0,
+          },
+          {
+            token_address: '6CAsXfiCXZfP8APCG6Vma2DFMindopxiqYQN4LSQfhoC',
+            avg_24h: 0.37,
+            max_24h: 0,
+            min_24h: 0,
+          },
+        ],
       });
 
     const res = await resolvers.Query.poolSnapshots({}, { limit: 1 });
@@ -68,18 +90,21 @@ describe('Query.poolSnapshots', () => {
     // timestamp should be seconds; pool_age should come from constants in your resolver
     expect(res.base).toMatchObject({
       average_price: 0.41,
+      avg_price_change_perc: 0.17142857142857143,
       pool_address: '0xpoolB',
       timestamp: Math.floor(1_754_998_299_000 / 1000),
       pool_age: 1724361475,
     });
     expect(res.ethereum).toMatchObject({
       average_price: 0.52,
+      avg_price_change_perc: 0.368421052631579,
       pool_address: '0xpoolE',
       timestamp: Math.floor(1_754_998_200_000 / 1000),
       pool_age: 1696841963,
     });
     expect(res.solana).toMatchObject({
       average_price: 0.63,
+      avg_price_change_perc: 0.7027027027027027,
       pool_address: '0xpoolS',
       timestamp: Math.floor(1_754_998_100_000 / 1000),
       pool_age: 1724398200,


### PR DESCRIPTION
This pull request enhances the pool snapshot API by adding a new field to track the percentage change in average price over the previous 24-hour period. It updates the resolver logic, schema, and corresponding unit tests to support and validate this new metric.

**API and Data Model Updates:**

* Added a new field, `avg_price_change_perc`, to the `PoolSnapshotRow` GraphQL type to expose the 24-hour average price change percentage.
* Updated the resolver logic in `resolvers.ts` to:
  - Calculate the previous 24-hour average price for each token.
  - Compute and populate `avg_price_change_perc` for each pool snapshot using the current and previous averages. [[1]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612L148-R154) [[2]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612L157-R186) [[3]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612R195-R228)

**Testing Improvements:**

* Enhanced unit tests in `poolSnapshots.test.ts` to mock the additional database query and verify that `avg_price_change_perc` is correctly calculated and returned for each pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-token 24h price-change percentage for Base, Ethereum, and Solana (avg_price_change_perc).
  - 24h stats now include previous-interval averages to support change calculations.
  - GraphQL now exposes avg_price_change_perc on pool snapshot entries.

- **Tests**
  - Updated unit tests to validate avg_price_change_perc using previous-interval 24h averages.
  - Existing average_price expectations preserved alongside new change-percentage assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->