### PR TITLE
release: dev -> main

### DIFF
--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -27,6 +27,7 @@ export const typeDefs = gql`
 
   type PoolSnapshotRow {
     average_price: Float!
+    avg_price_change_perc: Float!
     block_number: String!
     chain: Chain!
     circulating_supply: Float!

--- a/packages/api/tests/unit/resolvers/poolSnapshots.test.ts
+++ b/packages/api/tests/unit/resolvers/poolSnapshots.test.ts
@@ -61,6 +61,28 @@ describe('Query.poolSnapshots', () => {
             min_24h: 0,
           },
         ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            token_address: '0x764a726d9ced0433a8d7643335919deb03a9a935',
+            avg_24h: 0.35,
+            max_24h: 0,
+            min_24h: 0,
+          },
+          {
+            token_address: '0x67f4c72a50f8df6487720261e188f2abe83f57d7',
+            avg_24h: 0.38,
+            max_24h: 0,
+            min_24h: 0,
+          },
+          {
+            token_address: '6CAsXfiCXZfP8APCG6Vma2DFMindopxiqYQN4LSQfhoC',
+            avg_24h: 0.37,
+            max_24h: 0,
+            min_24h: 0,
+          },
+        ],
       });
 
     const res = await resolvers.Query.poolSnapshots({}, { limit: 1 });
@@ -68,18 +90,21 @@ describe('Query.poolSnapshots', () => {
     // timestamp should be seconds; pool_age should come from constants in your resolver
     expect(res.base).toMatchObject({
       average_price: 0.41,
+      avg_price_change_perc: 0.17142857142857143,
       pool_address: '0xpoolB',
       timestamp: Math.floor(1_754_998_299_000 / 1000),
       pool_age: 1724361475,
     });
     expect(res.ethereum).toMatchObject({
       average_price: 0.52,
+      avg_price_change_perc: 0.368421052631579,
       pool_address: '0xpoolE',
       timestamp: Math.floor(1_754_998_200_000 / 1000),
       pool_age: 1696841963,
     });
     expect(res.solana).toMatchObject({
       average_price: 0.63,
+      avg_price_change_perc: 0.7027027027027027,
       pool_address: '0xpoolS',
       timestamp: Math.floor(1_754_998_100_000 / 1000),
       pool_age: 1724398200,


### PR DESCRIPTION
This pull request enhances the pool snapshot API by adding support for tracking and exposing the 24-hour average price change percentage for each token pool. The changes include updates to the resolver logic, schema, and unit tests to support this new metric.

**API and Data Model Enhancements:**

* Added a new field, `avg_price_change_perc`, to the `PoolSnapshotRow` GraphQL type to expose the 24-hour average price change percentage.
* Updated the resolver logic in `resolvers.ts` to:
  - Query and calculate the previous 24-hour average price for each token pool.
  - Compute the percentage change between the current and previous 24-hour average prices, and include this value in the API response for each pool. [[1]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612L148-R186) [[2]](diffhunk://#diff-e6403b5a4d86c67c1598624117452fa49fbd03a56a81f4492c61ca21293cc612R195-R228)

**Testing Improvements:**

* Updated unit tests for the pool snapshot resolver to mock previous 24-hour average prices and verify the correct calculation and return of `avg_price_change_perc` in the API response.